### PR TITLE
Fix Org name Ream -> Hive

### DIFF
--- a/projects/project-ideas.md
+++ b/projects/project-ideas.md
@@ -31,7 +31,7 @@ https://security.ethereum.org/wishlist
 
 By Pari
 
-Ongoing wishlist of ideas for tools that help with development and testing of the protocol.
+Ongoing wishlist of ideas for tools that help with the development and testing of the protocol.
 
 https://github.com/ethpandaops/tooling-wishlist
 
@@ -51,7 +51,7 @@ By Giulio Rebuffo / Erigon
 
 [aglean](https://github.com/erigontech/aglean) is a Python Lean Ethereum consensus client together with an AI-driven cross-language generation framework. Today the repository already has a working Python implementation, fixture verification, and a live local-devnet sync path. The next step is to develop it further into a stronger EPF project by adding actual implementation permutations and improving overall stability.
 
-This project is about turning aglean from a one-shot client-porting demo into a more serious client-diversity engine. In particular, the work could include:
+This project is about turning Aglean from a one-shot client-porting demo into a more serious client-diversity engine. In particular, the work could include:
 
 - defining real interchangeable subspec permutations instead of a single baseline implementation,
 - improving stability and reproducibility of generated clients and verification runs,
@@ -62,25 +62,25 @@ Examples of such alternatives include different storage backends, sync strategie
 
 This project is a good fit for fellows interested in Lean Ethereum, client diversity, testing infrastructure, and AI-assisted client implementation.
 
-### Ream: Black Box Interop Testing Post Quantum Lean Ethereum
+### Hive: Black Box Interop Testing Post Quantum Lean Ethereum
 
 By Kolby ML and Derek Sorken
 
-The Ream team maintains the shared testing infrastructure for the post quantum movement for Ethereum (lean consensus) at https://hive.leanroadmap.org/, a black box testing framework that tests post quantum clients against a common suite of scenarios.
+The Ream team maintains the shared testing infrastructure for the post-quantum movement for Ethereum (Lean Consensus) at https://hive.leanroadmap.org/, a black-box testing framework that tests post-quantum clients against a common suite of scenarios.
 
 The project would be fully in Rust 🦀 and can be found on https://github.com/ethereum/hive.
 
-Every lean consensus client shipping runs through this testing framework, which means the work you do on this project directly impacts the lean ecosystem as it allows the post quantum effort to confidently scale devnets to larger validator sets and how quick teams can ship devnets against an evolving Post Quantum Ethereum spec (https://github.com/leanEthereum/leanSpec).
+Every lean consensus client shipping runs through this testing framework, which means the work you do on this project directly impacts the lean ecosystem as it allows the post quantum effort to confidently scale devnets to larger validator sets and how quickly teams can ship devnets against an evolving Post Quantum Ethereum spec (https://github.com/leanEthereum/leanSpec).
 
-This project would extend the testing infrastructure: adding new scenarios (spec tests, checkpoint tests, signature aggregation interop, state transition cross-checks, key lifecycle edge cases), onboarding new client implementations if required, and improving the framework itself which involves adding fixtures, runtime errors, handling test failures, and maintaining dashboards that show the state of the clients' performance in the tests.
+This project would extend the testing infrastructure: adding new scenarios (spec tests, checkpoint tests, signature aggregation interop, state transition cross-checks, key lifecycle edge cases), onboarding new client implementations if required, and improving the framework itself, which involves adding fixtures, runtime errors, handling test failures, and maintaining dashboards that show the state of the clients' performance in the tests.
 
 ### Ream: Operating and Scaling PQ Interop Devnets
 
 By Shariq Naiyer and Unnawut
 
-The Ream team wants to operate and scale the post quantum interop devnets, which involves deploying post quantum clients (lean consensus clients) in realistic configurations, running them under load, and observing how they behave together, reporting findings, surfacing bugs from these runs and fixing them.
+The Ream team wants to operate and scale the post quantum interop devnets, which involves deploying post quantum clients (lean consensus clients) in realistic configurations, running them under load, and observing how they behave together, reporting findings, surfacing bugs from these runs, and fixing them.
 
-Tooling to play around be found at https://github.com/ReamLabs/leanstart 🦀.
+Tooling to play around can be found at https://github.com/ReamLabs/leanstart 🦀.
 
 
 ### Ream: Execution Layer Integration for the Lean Chain
@@ -89,7 +89,7 @@ By Kolby ML and Shariq Naiyer
 
 The Post Quantum spec is currently consensus-only. Ream's blocks carry only attestations, and there is no way for a wallet to submit a transaction against a lean network.
 
-What made Ethereum different from what came before was that, for the first time, people could write programs backed by the same fundamental principles as Bitcoin. We think it would be cool to show that the same is true under PoC post-quantum testnet where users can send transactions and deploy smart contracts on a chain finalized in seconds, backend by post quantum security in Rust 🦀.
+What made Ethereum different from what came before was that, for the first time, people could write programs backed by the same fundamental principles as Bitcoin. We think it would be cool to show that the same is true under PoC post-quantum testnet, where users can send transactions and deploy smart contracts on a chain finalized in seconds, backed by post-quantum security in Rust 🦀.
 
 This project involves embedding reth (https://github.com/paradigmxyz/reth) directly into the Ream (https://github.com/ReamLabs/ream) binary as a library and driving it from inside the lean stack via reth's Execution Extensions (ExEx) framework. One process, no HTTP bridge between an Execution and Consensus. The success bar is a working "wallet → tx → block → confirmation" demo on a local lean devnet running as a single `ream lean_node` binary with reth embedded.
 
@@ -97,7 +97,7 @@ This project involves embedding reth (https://github.com/paradigmxyz/reth) direc
 
 By Shariq Naiyer and Kolby ML
 
-Data Availability is the guarantee that the data behind a transaction has been published somewhere any node can fetch and verify it. Currently there are only execution and consensus clients and DA is often bundled with a consensus client. We want to build a dedicated DA client that can plug into a minimal beacon client and a generic interface so it could plug into a post quantum consensus client in Rust 🦀.
+Data Availability is the guarantee that the data behind a transaction has been published somewhere that any node can fetch and verify. Currently, there are only execution and consensus clients, and DA is often bundled with a consensus client. We want to build a dedicated DA client that can plug into a minimal beacon client and a generic interface, so it can also plug into a post-quantum consensus client in Rust 🦀.
 
 This project builds a standalone `ream da-node` binary fully dedicated to the data layer: a Data layer client that custodies and serves the full 128 columns, and does the minimal amount of non-DAS work possible. No fork choice, no execution, no validator, just the data layer, decoupled from any one consensus runtime and runnable alongside a minimal consensus node.
 


### PR DESCRIPTION
Hive was incorrectly mentioned as Ream.

Also corrected capitalization, punctuation, and phrasing for clarity and consistency throughout the document.