### PR TITLE
Add eek 0 dev update for Meek

### DIFF
--- a/development-updates.md
+++ b/development-updates.md
@@ -24,6 +24,7 @@ Phase one is the very beginning of the cohort. The first few weeks are dedicated
 | [Kris](https://github.com/krisoshea-eth/)       | [Update 0](https://hackmd.io/@krisos/rJZ18M_-fg)                                                    |        |        |
 | [Mario](https://github.com/taxmeifyoucan/)      | [ Update 0](https://notes.ethereum.org/@MarioHavel/week0)                                           |        |        |
 | [Marko](https://github.com/markolazic01)        | [Update 0](https://hackmd.io/@lqzic/week-0-update)                                                  |        |        |
+| [Meek](https://github.com/mmsaki)               | [Update 0](https://hackmd.io/@YBDu_chCTnKXFnYTkux9tQ/HJ5Rqa1zzx)                                     |        |        |
 | [Mohit](https://github.com/groverInnovate)      | [Update 0](https://hackmd.io/@groverInnovate/EPF7_Week0)                                            |        |        |
 | [Rahul](https://github.com/rahulbarmann/)       | [Update 0](https://hackmd.io/@8t0zzURJSC6IX5BOuOiGqQ/Sk0vwhHZfg)                                    |        |        |
 | [Sagar](https://www.github.com/SoarinSkySagar)  | [Update 0](https://hackmd.io/@5d9IS104QYmhm-pr1ypNJg/Bk3xoWQbGg)                                    |        |        |

--- a/development-updates.md
+++ b/development-updates.md
@@ -24,7 +24,7 @@ Phase one is the very beginning of the cohort. The first few weeks are dedicated
 | [Kris](https://github.com/krisoshea-eth/)       | [Update 0](https://hackmd.io/@krisos/rJZ18M_-fg)                                                    |        |        |
 | [Mario](https://github.com/taxmeifyoucan/)      | [ Update 0](https://notes.ethereum.org/@MarioHavel/week0)                                           |        |        |
 | [Marko](https://github.com/markolazic01)        | [Update 0](https://hackmd.io/@lqzic/week-0-update)                                                  |        |        |
-| [Meek](https://github.com/mmsaki)               | [Update 0](https://hackmd.io/@YBDu_chCTnKXFnYTkux9tQ/HJ5Rqa1zzx)                                     |        |        |
+| [Meek](https://github.com/mmsaki)               | [Update 0](https://hackmd.io/@YBDu_chCTnKXFnYTkux9tQ/HJ5Rqa1zzx)                                     | [Update 1](https://hackmd.io/@YBDu_chCTnKXFnYTkux9tQ/rJvMCpJzfg) |        |
 | [Mohit](https://github.com/groverInnovate)      | [Update 0](https://hackmd.io/@groverInnovate/EPF7_Week0)                                            |        |        |
 | [Rahul](https://github.com/rahulbarmann/)       | [Update 0](https://hackmd.io/@8t0zzURJSC6IX5BOuOiGqQ/Sk0vwhHZfg)                                    |        |        |
 | [Sagar](https://www.github.com/SoarinSkySagar)  | [Update 0](https://hackmd.io/@5d9IS104QYmhm-pr1ypNJg/Bk3xoWQbGg)                                    |        |        |


### PR DESCRIPTION
Adding my Week 0 development update to the Phase 1 table.

I applied to EPF7 and wasn't selected for a stipend — I'm participating permissionlessly, following the cohort and posting updates in public as the rejection note encouraged. If this updates table is meant for stipend fellows only, no worries at all — point me to the right place and I'll move it.

**Project:** [`zeth`](https://github.com/mmsaki/zeth) — an Ethereum execution-layer client written from scratch in Zig, ported from the execution-specs as source of truth.

**Update 0:** https://hackmd.io/@YBDu_chCTnKXFnYTkux9tQ/HJ5Rqa1zzx

Current status: passes the official TrieTests (25/25) and EEST fixtures through Prague (EIP-7702/7685/7623 etc.); devp2p RLPx + discv4 + snap/1 against geth; and a block producer + mempool wired through the Engine API (forkchoiceUpdated → getPayload → newPayload round-trips VALID).