### PR TITLE
Add Ivan's Week 0 dev update

### DIFF
--- a/development-updates.md
+++ b/development-updates.md
@@ -20,6 +20,7 @@ Phase one is the very beginning of the cohort. The first few weeks are dedicated
 | [Cristian](https://github.com/conache/)         | [ Update 0](https://hackmd.io/@conache/rywURItWzx)                                                  |        |        |
 | [Ifeoluwa](https://github.com/owanikin)         |                                                   | [ Update 1](https://hackmd.io/@ZpBFaS-NSO-5Xkdm4jwolg/BJO7iYpWMx)       |        |
 | [Daniel](https://github.com/perfogic)           | [Update 0](https://hackmd.io/@rY6uGs23RIKpNYTQc4mY_g/SkvmzE0Zfe)                                    |        |        |
+| [Ivan](https://github.com/IvanAnishchuk)        | [Update 0](https://ivananishchuk.github.io/eth-protocol-fellowship/updates/2026-06-17-week-0/)      |        |        |
 | [Jack CC](https://github.com/JackCC703/)        | [Update 0](https://hackmd.io/@jackcc/epf7-week0)                                                    |        |        |
 | [Jeff](https://www.github.com/jeffoodchain)     | [Update 0](https://hackmd.io/BEM-xj5dRBeh3MGHYIvYeQ)                                                |        |        |
 | [Josh](https://github.com/JO-OLADEJI)           | [Update 0](https://hackmd.io/@hiOAMmPVSB6rKJF3A0TJIA/By6GJsnZGx)                                    |        |        |


### PR DESCRIPTION
Adds my Week 0 dev update to the Phase 1 table (row goes in alphabetically, between Daniel and Jack CC).

I hosted it on my own GitHub Pages site rather than HackMD: https://ivananishchuk.github.io/eth-protocol-fellowship/updates/2026-06-17-week-0/

Kept the change to the single row and matched the existing column widths, so the table alignment doesn't drift.