### PR TITLE
Add Kris week 3 development update

### DIFF
--- a/development-updates.md
+++ b/development-updates.md
@@ -87,7 +87,7 @@ With the gained insight into the protocol, the following weeks serve as a deep d
 | [Kapil](https://github.com/Kapil-K-Kathiriya)        |                                                  |        |        |                  |
 | [Keshav](https://www.github.com/keshavsharma25)      |                                                  |        |        |                  |
 | [Kimi](https://github.com/KimiWu123)                 | [Update 3](https://hackmd.io/@kimiwu/r1rDNxSmMx) |        |        |                  |
-| [Kris](https://github.com/krisoshea-eth/)            |                                                  |        |        |                  |
+| [Kris](https://github.com/krisoshea-eth/)            | [Update 3](https://hackmd.io/@krisos/BkiFy_KXMx) |        |        |                  |
 | [Mario](https://github.com/taxmeifyoucan/)           |                                                  |        |        |                  |
 | [Marko](https://github.com/markolazic01)             | [Update 3](https://hackmd.io/@lqzic/week-3-update) |        |        |                  |
 | [Mary](https://github.com/maryodior)                 |                                                  |        |        |                  |


### PR DESCRIPTION
Adds my EPF7 Week 3 development update to the Phase 2 deep dive table.

Validation:
- Synced local main and origin/main with upstream/main before branching.
- Verified the HackMD link returns HTTP 200.
- Confirmed the final diff only updates the Kris row.
- Ran python3 scripts/test_dev_updates.py.