### PR TITLE
Add Lodestar builder presentation link

### DIFF
--- a/projects/lodestar-eip-7732-builder.md
+++ b/projects/lodestar-eip-7732-builder.md
@@ -188,7 +188,7 @@ The project is successful if Lodestar has a working, tested, and documented hone
 ## Resources
 
 - **[Living technical note](https://hackmd.io/@krisos/S1a9mdB7fl)** -- companion document for the full PR map, code-path map, cache design, bid-policy notes, Deathstar notebook, and resource library
-- **Presentation** -- link to be added when the presentation exists
+- **[Presentation slides](https://docs.google.com/presentation/d/1cmC3fpu652gZFTIm2_P1lIYOfC2M_w3c5qXSUZ4B6lc)** -- Lodestar EIP-7732 Builder project presentation
 - [EIP-7732](https://eips.ethereum.org/EIPS/eip-7732) - Gloas [builder](https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/builder.md) and [p2p](https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/p2p-interface.md) specs - [EIP-7773 (Glamsterdam meta)](https://eips.ethereum.org/EIPS/eip-7773) - [EIP-8282 (builder deposits/exits)](https://eips.ethereum.org/EIPS/eip-8282)
 - EPF7 project ideas: [Builder](https://github.com/eth-protocol-fellows/cohort-seven/blob/master/projects/project-ideas.md#lodestar-eip-7732-builder) - [Deathstar](https://github.com/eth-protocol-fellows/cohort-seven/blob/master/projects/project-ideas.md#lodestar-adversarial-node)
 - [Lodestar](https://github.com/ChainSafe/lodestar) - the builder gap: [`produceBlockBody.ts`](https://github.com/ChainSafe/lodestar/blob/unstable/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts) - [Deathstar chaos catalog](https://github.com/ChainSafe/lodestar/blob/deathstar/EPBS_CHAOS_FEATURES.md)


### PR DESCRIPTION
## Summary

- Adds the Lodestar EIP-7732 Builder Google Slides presentation to the proposal Resources section.
- Replaces the old presentation placeholder now that the slides exist.

## Link verification

- Confirmed the Google Slides page loads without authentication and exposes the deck title.
- Confirmed the PDF export endpoint returns `application/pdf` for the deck without authentication.

## Validation

- Ran `git diff --check`.
